### PR TITLE
build(npm): Change the build folder name from build to dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ I'm just putting manually build files there to see if it works, but later we
 want to make this compile rollico.css from several files and auto extract the
 variable values into variables.js
 
+-TO DO: Add note about `npm install -g commitizen`
 https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@resmio/rollico",
   "version": "0.0.0-semantically-released",
-  "description": "A base style builder for resmio projects",
-  "main": "build/rollico.css",
+  "description": "A basic style guide for resmio projects",
+  "main": "dist/rollico.css",
+  "files": ["dist"],
   "repository": {
     "type": "git",
     "url": "https://github.com/resmio/rollico.git"
@@ -37,8 +38,10 @@
     "test": "npm help",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
-  "czConfig": {
-    "path": "node_modules/cz-conventional-changelog"
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-conventional-changelog"
+    }
   },
   "release": {
     "verifyConditions": "condition-circle"


### PR DESCRIPTION
Changes the name of the folder to the one we were listing under main.

BREAKING CHANGE: The variables now need to be imported from `@resmio/rollico/dist`

fixes #13